### PR TITLE
Earth Rotation in computeRange()

### DIFF
--- a/gpssim.c
+++ b/gpssim.c
@@ -978,6 +978,7 @@ void computeRange(range_t *rho, ephem_t eph, gpstime_t g, double xyz[])
 	double los[3];
 	double tau;
 	double range,rate;
+	double tmp;
 	
 	// SV position at time of the pseudorange observation.
 	satpos(eph, g, pos, vel, clk);
@@ -992,8 +993,9 @@ void computeRange(range_t *rho, ephem_t eph, gpstime_t g, double xyz[])
 	pos[2] -= vel[2]*tau;
 
 	// Earth rotation correction. The change in velocity can be neglected.
+	tmp = pos[0]*OMEGA_EARTH*tau;
 	pos[0] += pos[1]*OMEGA_EARTH*tau;
-	pos[1] -= pos[0]*OMEGA_EARTH*tau;
+	pos[1] -= tmp;
 
 	// New observer to satellite vector and satellite range.
 	subVect(los, pos, xyz);


### PR DESCRIPTION
> `pos[0] += pos[1]*`...
> `pos[1] -= pos[0]*`...

The second line might be incorrect because pos[0] has already been modified by the first line. The difference should be very small.

Please check with actual GPS receiver before merge. I have not yet succeeded to prepare the testing equipment.