### PR TITLE
Add bladerf.script, and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ tx config file=gpssim.bin format=bin
 tx start
 ```
 
+Also, you can execute those commandline below as `bladeRF-cli` script:
+
+```
+> bladeRF-cli -s bladerf.script
+```
+
 For the HackRF:
 
 ```

--- a/bladerf.script
+++ b/bladerf.script
@@ -1,0 +1,9 @@
+set frequency 1575.42M
+set samplerate 2.6M
+set bandwidth 2.5M
+set txvga1 -25
+cal lms
+cal dc tx
+tx config file=gpssim.bin format=bin
+tx start
+tx wait 


### PR DESCRIPTION
We can now easily use 

    bladeRF-cli -s bladerf.script

to set BladeRF to tx mode, which saves a lot of typing.

This command will block until transmitting is over, with a 

    tx wait

line.