### PR TITLE
Linux minor fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,6 @@ clean:
 	rm -f gpssim.o gps-sdr-sim *.bin
 
 time: gps-sdr-sim
+	time ./gps-sdr-sim -e brdc3540.14n -u circle.csv -b 1
 	time ./gps-sdr-sim -e brdc3540.14n -u circle.csv -b 8
 	time ./gps-sdr-sim -e brdc3540.14n -u circle.csv -b 16

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ all: gps-sdr-sim
 
 SHELL=/bin/bash
 CC=gcc
-CFLAGS=-fopenmp -O3 -Wall
-LDFLAGS=-lm -fopenmp
+CFLAGS=-O3 -Wall
+LDFLAGS=-lm
 
 gps-sdr-sim: gpssim.o
 	${CC} $< ${LDFLAGS} -o $@

--- a/gpssim.c
+++ b/gpssim.c
@@ -1558,7 +1558,6 @@ int main(int argc, char *argv[])
 	double llh[3];
 	
 	int i;
-	int nsat;
 	channel_t chan[MAX_CHAN];
 	double elvmask = 0.0; // in degree
 
@@ -1903,7 +1902,7 @@ int main(int argc, char *argv[])
 	grx = g0;
 
 	// Allocate visible satellites
-	nsat = allocateChannel(chan, eph[ieph], grx, xyz[0], elvmask);
+	allocateChannel(chan, eph[ieph], grx, xyz[0], elvmask);
 
 	for(i=0; i<MAX_CHAN; i++)
 	{
@@ -2060,7 +2059,7 @@ int main(int argc, char *argv[])
 					generateNavMsg(grx, &chan[i], 0);
 
 			// Update channel allocation
-			nsat = allocateChannel(chan, eph[ieph], grx, xyz[iumd], elvmask);
+			allocateChannel(chan, eph[ieph], grx, xyz[iumd], elvmask);
 
 			// Show ditails about simulated channels
 			if (verb)


### PR DESCRIPTION
Maintenance minor fixes for Linux build.

* Remove openmp flags.
* Add 1-bit mode for time test.
* Fix: warning: variable 'nsat' set but not used

You may want to omit the Fix above.