### PR TITLE
Fixed uninitiated warnings

### DIFF
--- a/gpssim.c
+++ b/gpssim.c
@@ -1943,6 +1943,14 @@ int main(int argc, char *argv[])
 		}
 	}
 
+	gmax.sec = 0;
+	gmax.week = 0;
+	tmax.sec = 0;
+	tmax.mm = 0;
+	tmax.hh = 0;
+	tmax.d = 0;
+	tmax.m = 0;
+	tmax.y = 0;
 	for (sv=0; sv<MAX_SAT; sv++)
 	{
 		if (eph[neph-1][sv].vflg == 1)


### PR DESCRIPTION
When compiling gpssim.c GCC warns about uninitiated values. Since it was trivial to set values for them, I did so to clear warnings. For normal operation these should be properly set regardless.