### PR TITLE
File larger than 2GB on 32-bit system ; possibility to output to stdout ; add an SDR player for LimeSDR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: gps-sdr-sim
 
 SHELL=/bin/bash
 CC=gcc
-CFLAGS=-O3 -Wall
+CFLAGS=-O3 -Wall -D_FILE_OFFSET_BITS=64
 LDFLAGS=-lm
 
 gps-sdr-sim: gpssim.o

--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ For UHD supported devices (tested with USRP2 only):
 > gps-sdr-sim-uhd.py -t gpssim.bin -s 2500000 -x 0
 ```
 
+For LimeSDR (in case of 1 Msps 1-bit file, to get full BaseBand dynamic and low RF power):
+
+> limeplayer -s 1000000 -b 1 -d 2047 -g 0.1 < ../circle.1b.1M.bin
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Options:
   -t <date,time>   Scenario start time YYYY/MM/DD,hh:mm:ss
   -T <date,time>   Overwrite TOC and TOE to scenario start time
   -d <duration>    Duration [sec] (dynamic mode max: 300 static mode max: 86400)
-  -o <output>      I/Q sampling data file (default: gpssim.bin)
+  -o <output>      I/Q sampling data file (default: gpssim.bin ; use - for stdout)
   -s <frequency>   Sampling frequency [Hz] (default: 2600000)
   -b <iq_bits>     I/Q data format [1/8/16] (default: 16)
   -i               Disable ionospheric delay for spacecraft scenario

--- a/gpssim.c
+++ b/gpssim.c
@@ -1512,7 +1512,7 @@ int generateNavMsg(gpstime_t g, channel_t *chan, int init)
 		// Sanity check
 		if (((chan->dwrd[1])&(0x1FFFFUL<<13)) != ((tow&0x1FFFFUL)<<13))
 		{
-			printf("\nWARNING: Invalid TOW in subframe 5.\n");
+			fprintf(stderr, "\nWARNING: Invalid TOW in subframe 5.\n");
 			return(0);
 		}
 		*/
@@ -1646,7 +1646,7 @@ int allocateChannel(channel_t *chan, ephem_t *eph, ionoutc_t ionoutc, gpstime_t 
 
 void usage(void)
 {
-	printf("Usage: gps-sdr-sim [options]\n"
+	fprintf(stderr, "Usage: gps-sdr-sim [options]\n"
 		"Options:\n"
 		"  -e <gps_nav>     RINEX navigation file for GPS ephemerides (required)\n"
 		"  -u <user_motion> User motion file (dynamic mode)\n"
@@ -1779,7 +1779,7 @@ int main(int argc, char *argv[])
 			samp_freq = atof(optarg);
 			if (samp_freq<1.0e6)
 			{
-				printf("ERROR: Invalid sampling frequency.\n");
+				fprintf(stderr, "ERROR: Invalid sampling frequency.\n");
 				exit(1);
 			}
 			break;
@@ -1787,7 +1787,7 @@ int main(int argc, char *argv[])
 			data_format = atoi(optarg);
 			if (data_format!=SC01 && data_format!=SC08 && data_format!=SC16)
 			{
-				printf("ERROR: Invalid I/Q data format.\n");
+				fprintf(stderr, "ERROR: Invalid I/Q data format.\n");
 				exit(1);
 			}
 			break;
@@ -1817,7 +1817,7 @@ int main(int argc, char *argv[])
 			if (t0.y<=1980 || t0.m<1 || t0.m>12 || t0.d<1 || t0.d>31 ||
 				t0.hh<0 || t0.hh>23 || t0.mm<0 || t0.mm>59 || t0.sec<0.0 || t0.sec>=60.0)
 			{
-				printf("ERROR: Invalid date and time.\n");
+				fprintf(stderr, "ERROR: Invalid date and time.\n");
 				exit(1);
 			}
 			t0.sec = floor(t0.sec);
@@ -1843,7 +1843,7 @@ int main(int argc, char *argv[])
 
 	if (navfile[0]==0)
 	{
-		printf("ERROR: GPS ephemeris file is not specified.\n");
+		fprintf(stderr, "ERROR: GPS ephemeris file is not specified.\n");
 		exit(1);
 	}
 
@@ -1858,7 +1858,7 @@ int main(int argc, char *argv[])
 
 	if (duration<0.0 || (duration>((double)USER_MOTION_SIZE)/10.0 && !staticLocationMode) || (duration>STATIC_MAX_DURATION && staticLocationMode))
 	{
-		printf("ERROR: Invalid duration.\n");
+		fprintf(stderr, "ERROR: Invalid duration.\n");
 		exit(1);
 	}
 	iduration = (int)(duration*10.0 + 0.5);
@@ -1884,12 +1884,12 @@ int main(int argc, char *argv[])
 
 		if (numd==-1)
 		{
-			printf("ERROR: Failed to open user motion / NMEA GGA file.\n");
+			fprintf(stderr, "ERROR: Failed to open user motion / NMEA GGA file.\n");
 			exit(1);
 		}
 		else if (numd==0)
 		{
-			printf("ERROR: Failed to read user motion / NMEA GGA data.\n");
+			fprintf(stderr, "ERROR: Failed to read user motion / NMEA GGA data.\n");
 			exit(1);
 		}
 
@@ -1901,14 +1901,14 @@ int main(int argc, char *argv[])
 	{ 
 		// Static geodetic coordinates input mode: "-l"
 		// Added by scateu@gmail.com 
-		printf("Using static location mode.\n");
+		fprintf(stderr, "Using static location mode.\n");
 		llh2xyz(llh,xyz[0]); // Convert llh to xyz
 
 		numd = iduration;
 	}
 /*
-	printf("xyz = %11.1f, %11.1f, %11.1f\n", xyz[0][0], xyz[0][1], xyz[0][2]);
-	printf("llh = %11.6f, %11.6f, %11.1f\n", llh[0]*R2D, llh[1]*R2D, llh[2]);
+	fprintf(stderr, "xyz = %11.1f, %11.1f, %11.1f\n", xyz[0][0], xyz[0][1], xyz[0][2]);
+	fprintf(stderr, "llh = %11.6f, %11.6f, %11.1f\n", llh[0]*R2D, llh[1]*R2D, llh[2]);
 */
 	////////////////////////////////////////////////////////////
 	// Read ephemeris
@@ -1918,19 +1918,19 @@ int main(int argc, char *argv[])
 
 	if (neph==0)
 	{
-		printf("ERROR: No ephemeris available.\n");
+		fprintf(stderr, "ERROR: No ephemeris available.\n");
 		exit(1);
 	}
 
 	if ((verb==TRUE)&&(ionoutc.vflg==TRUE))
 	{
-		printf("  %12.3e %12.3e %12.3e %12.3e\n", 
+		fprintf(stderr, "  %12.3e %12.3e %12.3e %12.3e\n", 
 			ionoutc.alpha0, ionoutc.alpha1, ionoutc.alpha2, ionoutc.alpha3);
-		printf("  %12.3e %12.3e %12.3e %12.3e\n", 
+		fprintf(stderr, "  %12.3e %12.3e %12.3e %12.3e\n", 
 			ionoutc.beta0, ionoutc.beta1, ionoutc.beta2, ionoutc.beta3);
-		printf("   %19.11e %19.11e  %9d %9d\n",
+		fprintf(stderr, "   %19.11e %19.11e  %9d %9d\n",
 			ionoutc.A0, ionoutc.A1, ionoutc.tot, ionoutc.wnt);
-		printf("%6d\n", ionoutc.dtls);
+		fprintf(stderr, "%6d\n", ionoutc.dtls);
 	}
 
 	for (sv=0; sv<MAX_SAT; sv++) 
@@ -2003,11 +2003,11 @@ int main(int argc, char *argv[])
 		{
 			if (subGpsTime(g0, gmin)<0.0 || subGpsTime(gmax, g0)<0.0)
 			{
-				printf("ERROR: Invalid start time.\n");
-				printf("tmin = %4d/%02d/%02d,%02d:%02d:%02.0f (%d:%.0f)\n", 
+				fprintf(stderr, "ERROR: Invalid start time.\n");
+				fprintf(stderr, "tmin = %4d/%02d/%02d,%02d:%02d:%02.0f (%d:%.0f)\n", 
 					tmin.y, tmin.m, tmin.d, tmin.hh, tmin.mm, tmin.sec,
 					gmin.week, gmin.sec);
-				printf("tmax = %4d/%02d/%02d,%02d:%02d:%02.0f (%d:%.0f)\n", 
+				fprintf(stderr, "tmax = %4d/%02d/%02d,%02d:%02d:%02.0f (%d:%.0f)\n", 
 					tmax.y, tmax.m, tmax.d, tmax.hh, tmax.mm, tmax.sec,
 					gmax.week, gmax.sec);
 				exit(1);
@@ -2020,9 +2020,9 @@ int main(int argc, char *argv[])
 		t0 = tmin;
 	}
 
-	printf("Start time = %4d/%02d/%02d,%02d:%02d:%02.0f (%d:%.0f)\n", 
+	fprintf(stderr, "Start time = %4d/%02d/%02d,%02d:%02d:%02.0f (%d:%.0f)\n", 
 		t0.y, t0.m, t0.d, t0.hh, t0.mm, t0.sec, g0.week, g0.sec);
-	printf("Duration = %.1f [sec]\n", ((double)numd)/10.0);
+	fprintf(stderr, "Duration = %.1f [sec]\n", ((double)numd)/10.0);
 
 	// Select the current set of ephemerides
 	ieph = -1;
@@ -2048,7 +2048,7 @@ int main(int argc, char *argv[])
 
 	if (ieph == -1)
 	{
-		printf("ERROR: No current set of ephemerides has been found.\n");
+		fprintf(stderr, "ERROR: No current set of ephemerides has been found.\n");
 		exit(1);
 	}
 
@@ -2061,7 +2061,7 @@ int main(int argc, char *argv[])
 
 	if (iq_buff==NULL)
 	{
-		printf("ERROR: Faild to allocate 16-bit I/Q buffer.\n");
+		fprintf(stderr, "ERROR: Faild to allocate 16-bit I/Q buffer.\n");
 		exit(1);
 	}
 
@@ -2070,7 +2070,7 @@ int main(int argc, char *argv[])
 		iq8_buff = calloc(2*iq_buff_size, 1);
 		if (iq8_buff==NULL)
 		{
-			printf("ERROR: Faild to allocate 8-bit I/Q buffer.\n");
+			fprintf(stderr, "ERROR: Faild to allocate 8-bit I/Q buffer.\n");
 			exit(1);
 		}
 	}
@@ -2079,16 +2079,21 @@ int main(int argc, char *argv[])
 		iq8_buff = calloc(iq_buff_size/4, 1); // byte = {I0, Q0, I1, Q1, I2, Q2, I3, Q3}
 		if (iq8_buff==NULL)
 		{
-			printf("ERROR: Faild to allocate compressed 1-bit I/Q buffer.\n");
+			fprintf(stderr, "ERROR: Faild to allocate compressed 1-bit I/Q buffer.\n");
 			exit(1);
 		}
 	}
 
 	// Open output file
-	if (NULL==(fp=fopen(outfile,"wb")))
-	{
-		printf("ERROR: Failed to open output file.\n");
-		exit(1);
+	// "-" can be used as name for stdout
+	if(strcmp("-", outfile)){
+		if (NULL==(fp=fopen(outfile,"wb")))
+		{
+			fprintf(stderr, "ERROR: Failed to open output file.\n");
+			exit(1);
+		}
+	}else{
+		fp = stdout;
 	}
 
 	////////////////////////////////////////////////////////////
@@ -2112,7 +2117,7 @@ int main(int argc, char *argv[])
 	for(i=0; i<MAX_CHAN; i++)
 	{
 		if (chan[i].prn>0)
-			printf("%02d %6.1f %5.1f %11.1f %5.1f\n", chan[i].prn, 
+			fprintf(stderr, "%02d %6.1f %5.1f %11.1f %5.1f\n", chan[i].prn, 
 				chan[i].azel[0]*R2D, chan[i].azel[1]*R2D, chan[i].rho0.d, chan[i].rho0.iono_delay);
 	}
 
@@ -2205,7 +2210,7 @@ int main(int argc, char *argv[])
 								chan[i].iword++;
 								/*
 								if (chan[i].iword>=N_DWRD)
-									printf("\nWARNING: Subframe word buffer overflow.\n");
+									fprintf(stderr, "\nWARNING: Subframe word buffer overflow.\n");
 								*/
 							}
 
@@ -2302,11 +2307,11 @@ int main(int argc, char *argv[])
 			// Show ditails about simulated channels
 			if (verb==TRUE)
 			{
-				printf("\n");
+				fprintf(stderr, "\n");
 				for (i=0; i<MAX_CHAN; i++)
 				{
 					if (chan[i].prn>0)
-						printf("%02d %6.1f %5.1f %11.1f %5.1f\n", chan[i].prn,
+						fprintf(stderr, "%02d %6.1f %5.1f %11.1f %5.1f\n", chan[i].prn,
 							chan[i].azel[0]*R2D, chan[i].azel[1]*R2D, chan[i].rho0.d, chan[i].rho0.iono_delay);
 				}
 			}
@@ -2316,13 +2321,13 @@ int main(int argc, char *argv[])
 		grx = incGpsTime(grx, 0.1);
 
 		// Update time counter
-		printf("\rTime into run = %4.1f", subGpsTime(grx, g0));
+		fprintf(stderr, "\rTime into run = %4.1f", subGpsTime(grx, g0));
 		fflush(stdout);
 	}
 
 	tend = clock();
 
-	printf("\nDone!\n");
+	fprintf(stderr, "\nDone!\n");
 
 	// Free I/Q buffer
 	free(iq_buff);
@@ -2331,7 +2336,7 @@ int main(int argc, char *argv[])
 	fclose(fp);
 
 	// Process time
-	printf("Process time = %.1f [sec]\n", (double)(tend-tstart)/CLOCKS_PER_SEC);
+	fprintf(stderr, "Process time = %.1f [sec]\n", (double)(tend-tstart)/CLOCKS_PER_SEC);
 
 	return(0);
 }

--- a/player/Makefile
+++ b/player/Makefile
@@ -1,0 +1,5 @@
+CC=gcc -g -Wall
+
+limeplayer: limeplayer.c
+	$(CC) -o limeplayer limeplayer.c -lLimeSuite
+

--- a/player/Makefile
+++ b/player/Makefile
@@ -1,4 +1,4 @@
-CC=gcc -g -Wall
+CC=gcc -O2 -Wall
 
 limeplayer: limeplayer.c
 	$(CC) -o limeplayer limeplayer.c -lLimeSuite

--- a/player/limeplayer.c
+++ b/player/limeplayer.c
@@ -304,7 +304,7 @@ int main(int argc, char *const argv[]){
 			if(16 == bits){
 				// Scale down to 12-bit
 				// Quick and dirty, so -1 (0xFFFF) to -15 (0xFFF1) scale down to -1 instead of 0
-				int i;
+				int i = 0;
 				while(i < nSamples){
 					sampleBuffer[i].i >>= 4;
 					sampleBuffer[i].q >>= 4;

--- a/player/limeplayer.c
+++ b/player/limeplayer.c
@@ -1,0 +1,340 @@
+#define _CRT_SECURE_NO_DEPRECATE
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <time.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <getopt.h>
+
+#include <lime/LimeSuite.h>
+
+#define EXIT_CODE_NO_DEVICE (-1)
+#define EXIT_CODE_LMS_OPEN  (-1)
+
+#define TX_FREQUENCY    1575420000.0
+#define TX_SAMPLERATE   2500000.0
+#define TX_BANDWIDTH    5000000.0
+#define DEFAULT_ANTENNA 1 // antenna with BW [30MHz .. 2000MHz]
+
+int main(int argc, char *const argv[]){
+	int device_count = LMS_GetDeviceList(NULL);
+	if(device_count < 1){
+		return(EXIT_CODE_NO_DEVICE);
+	}
+	lms_info_str_t *device_list = malloc(sizeof(lms_info_str_t) * device_count);
+	device_count = LMS_GetDeviceList(device_list);
+
+	int i = 0;
+	while(i < device_count){
+		// printf("device[%d/%d]=%s" "\n", i + 1, device_count, device_list[i]);
+		i++;
+	}
+
+	double gain = 1.0;
+	int antenna = DEFAULT_ANTENNA;
+	int channel = 0;
+	int index = 0;
+	int bits = 16;
+	double sampleRate = TX_SAMPLERATE;
+
+    while (1) {
+        int option_index = 0;
+        static struct option long_options[] = {
+            {"gain",   required_argument, 0,  'g' },
+            {"channel",   required_argument, 0,  'c' },
+            {"antenna",   required_argument, 0,  'a' },
+            {"index", required_argument, 0, 'i'},
+            {"bits", required_argument, 0, 'b'},
+            {"samplerate", required_argument, 0, 's'},
+            {0,         0,                 0,  0 }
+        };
+
+        int c = getopt_long(argc, argv, "g:c:a:i:s:b:", long_options, &option_index);
+        if (c == -1)
+        break;
+
+        switch (c) {
+            case 0:
+            #if 1
+            fprintf(stderr, "option %s", long_options[option_index].name);
+            if (optarg)
+				fprintf(stderr, " with arg %s", optarg);
+            fprintf(stderr, "\n");
+            #endif
+
+            break;
+
+            case 'a':
+                antenna = strtol(optarg, NULL, 0);
+            break;
+            case 'b':
+                bits = strtol(optarg, NULL, 0);
+            break;
+            case 'c':
+                channel = strtol(optarg, NULL, 0);
+            break;
+            case 'g':
+                gain = strtod(optarg, NULL);
+            break;
+            case 'i':
+                index = strtol(optarg, NULL, 0);
+            break;
+	    case 's':
+	    	sampleRate = strtod(optarg, NULL);
+	    break;
+        }
+    }
+	// Use correct values
+	// Use existing device
+	if(index < 0){
+		index = 0;
+	}
+	if(index >= device_count){
+		index = 0;
+	}
+	printf("Using device index %d [%s]" "\n", index, device_list[index]);
+
+	// Normalized gain shall be in [0.0 .. 1.0]
+	if(gain < 0.0){
+		gain = 0.0;
+	}
+	if(gain > 1.0){
+		gain = 1.0;
+	}
+	printf("Using normalized gain %lf" "\n", gain);
+
+
+	lms_device_t *device = NULL;
+
+	if(LMS_Open(&device, device_list[index], NULL)){
+		return(EXIT_CODE_LMS_OPEN);
+	}
+
+	int lmsReset = LMS_Reset(device);
+	if(lmsReset){
+		printf("lmsReset %d(%s)" "\n", lmsReset, LMS_GetLastErrorMessage());
+	}
+	int lmsInit = LMS_Init(device);
+	if(lmsInit){
+		printf("lmsInit %d(%s)" "\n", lmsInit, LMS_GetLastErrorMessage());
+	}
+
+	int channel_count = LMS_GetNumChannels(device, LMS_CH_TX);
+	// printf("Tx channel count %d" "\n", channel_count);
+	if(channel < 0){
+		channel = 0;
+	}
+	if(channel >= channel_count){
+		channel = 0;
+	}
+	printf("Using channel %d" "\n", channel);
+
+	int antenna_count = LMS_GetAntennaList(device, LMS_CH_TX, channel, NULL);
+	// printf("TX%d Channel has %d antenna(ae)" "\n", channel, antenna_count);
+	lms_name_t antenna_name[antenna_count];
+	if(antenna_count > 0){
+		int i = 0;
+		lms_range_t antenna_bw[antenna_count];
+		LMS_GetAntennaList(device, LMS_CH_TX, channel, antenna_name);
+		for(i = 0 ; i < antenna_count ; i++){
+			LMS_GetAntennaBW(device, LMS_CH_TX, channel, i, antenna_bw + i);
+			// printf("Channel %d, antenna [%s] has BW [%lf .. %lf] (step %lf)" "\n", channel, antenna_name[i], antenna_bw[i].min, antenna_bw[i].max, antenna_bw[i].step);
+		}
+	}
+	if(antenna < 0){
+		antenna = DEFAULT_ANTENNA;
+	}
+	if(antenna >= antenna_count){
+		antenna = DEFAULT_ANTENNA;
+	}
+	// LMS_SetAntenna(device, LMS_CH_TX, channel, antenna); // SetLOFrequency should take care of selecting the proper antenna
+	
+	LMS_SetNormalizedGain(device, LMS_CH_TX, channel, gain);
+	// Disable all other channels
+	LMS_EnableChannel(device, LMS_CH_TX, 1 - channel, false);
+	LMS_EnableChannel(device, LMS_CH_RX, 0, false);
+	LMS_EnableChannel(device, LMS_CH_RX, 1, false);
+	// Enable our Tx channel
+	LMS_EnableChannel(device, LMS_CH_TX, channel, true);
+
+	int setLOFrequency = LMS_SetLOFrequency(device, LMS_CH_TX, channel, TX_FREQUENCY);
+	if(setLOFrequency){
+		printf("setLOFrequency(%lf)=%d(%s)" "\n", TX_FREQUENCY, setLOFrequency, LMS_GetLastErrorMessage());
+	}
+
+#ifdef __USE_LPF__
+	lms_range_t LPFBWRange;
+	LMS_GetLPFBWRange(device, LMS_CH_TX, &LPFBWRange);
+	// printf("TX%d LPFBW [%lf .. %lf] (step %lf)" "\n", channel, LPFBWRange.min, LPFBWRange.max, LPFBWRange.step);
+	double LPFBW = TX_BANDWIDTH;
+	if(LPFBW < LPFBWRange.min){
+		LPFBW = LPFBWRange.min;
+	}
+	if(LPFBW > LPFBWRange.max){
+		LPFBW = LPFBWRange.min;
+	}
+	int setLPFBW = LMS_SetLPFBW(device, LMS_CH_TX, channel, LPFBW);
+	if(setLPFBW){
+		printf("setLPFBW(%lf)=%d(%s)" "\n", LPFBW, setLPFBW, LMS_GetLastErrorMessage());
+	}
+	int enableLPF = LMS_SetLPF(device, LMS_CH_TX, channel, true);
+	if(enableLPF){
+		printf("enableLPF=%d(%s)" "\n", enableLPF, LMS_GetLastErrorMessage());
+	}
+#endif
+
+	lms_range_t sampleRateRange;
+	int getSampleRateRange = LMS_GetSampleRateRange(device, LMS_CH_TX, &sampleRateRange);
+	if(getSampleRateRange){
+		printf("getSampleRateRange=%d(%s)" "\n", getSampleRateRange, LMS_GetLastErrorMessage());
+	}else{
+		// printf("sampleRateRange [%lf MHz.. %lf MHz] (step=%lf Hz)" "\n", sampleRateRange.min / 1e6, sampleRateRange.max / 1e6, sampleRateRange.step);
+	}
+
+	printf("Set sample rate to %lf ..." "\n", sampleRate);
+	int setSampleRate = LMS_SetSampleRate(device, sampleRate, 0);
+	if(setSampleRate){
+		printf("setSampleRate=%d(%s)" "\n", setSampleRate, LMS_GetLastErrorMessage());
+	}
+	double actualHostSampleRate = 0.0;
+	double actualRFSampleRate = 0.0;
+	int getSampleRate = LMS_GetSampleRate(device, LMS_CH_TX, channel, &actualHostSampleRate, &actualRFSampleRate);
+	if(getSampleRate){
+		printf("getSampleRate=%d(%s)" "\n", getSampleRate, LMS_GetLastErrorMessage());
+	}else{
+		printf("actualRate %lf (Host) / %lf (RF)" "\n", actualHostSampleRate, actualRFSampleRate);
+	}
+
+	printf("Calibrating ..." "\n");
+	int calibrate = LMS_Calibrate(device, LMS_CH_TX, channel, TX_BANDWIDTH, 0);
+	if(calibrate){
+		printf("calibrate=%d(%s)" "\n", calibrate, LMS_GetLastErrorMessage());
+	}
+
+	printf("Setup TX stream ..." "\n");
+	lms_stream_t tx_stream = {.channel = channel, .fifoSize = 1024*1024, .throughputVsLatency = 0.5, .isTx = true, .dataFmt = LMS_FMT_I12};
+	int setupStream = LMS_SetupStream(device, &tx_stream);
+	if(setupStream){
+		printf("setupStream=%d(%s)" "\n", setupStream, LMS_GetLastErrorMessage());
+	}
+
+	struct s16iq_sample_s {
+		signed short int i;
+		signed short int q;
+	};
+
+	int nSamples = (int)sampleRate / 100;
+	struct s16iq_sample_s *sampleBuffer = (struct s16iq_sample_s*)malloc(sizeof(struct s16iq_sample_s) * nSamples);
+
+	LMS_StartStream(&tx_stream);
+
+	int loop = 0;
+	if((12 == bits) || (16 == bits)){
+		// File contains interleaved 16-bit IQ values, either with only 12-bit data, or with 16-bit data
+		while(fread(sampleBuffer, sizeof(struct s16iq_sample_s), nSamples, stdin)){
+			loop++;
+			if(0 == (loop % 100)){
+				struct timeval tv;
+				gettimeofday(&tv, NULL);
+				printf("gettimeofday()=> %ld:%06ld ; ", tv.tv_sec, tv.tv_usec);
+				lms_stream_status_t status;
+				LMS_GetStreamStatus(&tx_stream, &status); //Obtain TX stream stats
+				printf("TX rate:%lf MB/s" "\n", status.linkRate / 1e6);
+			}
+			if(16 == bits){
+				// Scale down to 12-bit
+				// Quick and dirty, so -1 (0xFFFF) to -15 (0xFFF1) scale down to -1 instead of 0
+				int i;
+				while(i < nSamples){
+					sampleBuffer[i].i >>= 4;
+					sampleBuffer[i].q >>= 4;
+					i++;
+				}
+			}
+			int sendStream = LMS_SendStream(&tx_stream, sampleBuffer, nSamples, NULL, 1000);
+			if(sendStream < 0){
+				printf("sendStream %d(%s)" "\n", sendStream, LMS_GetLastErrorMessage());
+			}
+		}
+	}else if(8 == bits){
+		// File contains interleaved signed 8-bit IQ values
+		struct s8iq_sample_s {
+			signed char i;
+			signed char q;
+		};
+		struct s8iq_sample_s *fileSamples = (struct s8iq_sample_s*)malloc(sizeof(struct s8iq_sample_s) * nSamples);
+		while(fread(fileSamples, sizeof(struct s8iq_sample_s), nSamples, stdin)){
+			loop++;
+			if(0 == (loop % 100)){
+				struct timeval tv;
+				gettimeofday(&tv, NULL);
+				printf("gettimeofday()=> %ld:%06ld ; ", tv.tv_sec, tv.tv_usec);
+				lms_stream_status_t status;
+				LMS_GetStreamStatus(&tx_stream, &status); //Obtain TX stream stats
+				printf("TX rate:%lf MB/s" "\n", status.linkRate / 1e6);
+			}
+			// Up-Scale to 12-bit
+			int i;
+			while(i < nSamples){
+				sampleBuffer[i].i = (fileSamples[i].i << 4);
+				sampleBuffer[i].q = (fileSamples[i].q << 4);
+				i++;
+			}
+			int sendStream = LMS_SendStream(&tx_stream, sampleBuffer, nSamples, NULL, 1000);
+			if(sendStream < 0){
+				printf("sendStream %d(%s)" "\n", sendStream, LMS_GetLastErrorMessage());
+			}
+		}
+		free(fileSamples);
+	}else if(1 == bits){
+		// File contains interleaved signed 1-bit IQ values
+		// Each byte is IQIQIQIQ
+		int16_t expand_lut[256][8];
+		int i, j;
+		for (i=0; i<256; i++){
+			for (j=0; j<8; j++){
+				expand_lut[i][j] = ((i>>(7-j))&0x1)?1024:-1024;
+			}
+		}
+		// printf("sizeof(expand_lut[][])=%d, sizeof(expand_lut[0])=%d" "\n", sizeof(expand_lut), sizeof(expand_lut[0]));
+		int8_t *fileBuffer = (int8_t*)malloc(sizeof(int8_t) * nSamples);
+		while(fread(fileBuffer, sizeof(int8_t), nSamples / 4, stdin)){
+			loop++;
+			if(0 == (loop % 100)){
+				struct timeval tv;
+				gettimeofday(&tv, NULL);
+				printf("gettimeofday()=> %ld:%06ld ; ", tv.tv_sec, tv.tv_usec);
+				lms_stream_status_t status;
+				LMS_GetStreamStatus(&tx_stream, &status); //Obtain TX stream stats
+				printf("TX rate:%lf MB/s" "\n", status.linkRate / 1e6);
+			}
+			// Expand
+			int src = 0;
+			int dst = 0;
+			while(src < (nSamples / 4)){
+				memcpy(sampleBuffer + dst, expand_lut + fileBuffer[src], sizeof(expand_lut[0]));
+				dst += 4;
+				src++;
+			}
+			int sendStream = LMS_SendStream(&tx_stream, sampleBuffer, nSamples, NULL, 1000);
+			if(sendStream < 0){
+				printf("sendStream %d(%s)" "\n", sendStream, LMS_GetLastErrorMessage());
+			}
+		}
+		free(fileBuffer);
+	}
+
+	LMS_StopStream(&tx_stream);
+	LMS_DestroyStream(device, &tx_stream);
+
+	free(sampleBuffer);
+
+	LMS_EnableChannel(device, LMS_CH_TX, channel, false);
+	LMS_Close(device);
+
+	return(0);
+}
+

--- a/player/limeplayer.c
+++ b/player/limeplayer.c
@@ -334,7 +334,7 @@ int main(int argc, char *const argv[]){
 				printf("TX rate:%lf MB/s" "\n", status.linkRate / 1e6);
 			}
 			// Up-Scale to 12-bit
-			int i;
+			int i = 0;
 			while(i < nSamples){
 				sampleBuffer[i].i = (fileSamples[i].i << 4);
 				sampleBuffer[i].q = (fileSamples[i].q << 4);

--- a/player/limeplayer.c
+++ b/player/limeplayer.c
@@ -36,7 +36,7 @@ static void print_usage(const char *progname){
             "\t" "-c <channel> or --channel <channel> with channel either 0 or 1 (default: 0)" "\n"
             "\t" "-a <antenna> or --antenna <antenna> with antenna in { 0, 1, 2 } (default:" STRINGIFY(DEFAULT_ANTENNA) ")" "\n"
             "\t" "-i <index> or --index <index> select LimeSDR if multiple devices connected (default: 0)" "\n"
-            "\t" "-b <bits> or --bits <bits> select bit count in IQ sample in { 1, 8, 12, 16 }, (default: 16)"
+            "\t" "-b <bits> or --bits <bits> select bit count in IQ sample in { 1, 8, 12, 16 }, (default: 16)" "\n"
             "\t" "-s <samplerate> or --samplerate <samplerate> configure BB sample rate (default: " STRINGIFY(TX_SAMPLERATE) ")" "\n"
             "\t" "-d <dynamic> --dynamic <dynamic> configure dynamic for the 1-bit mode (default: 2047, max 12-bit signed value supported by LimeSDR)" "\n"
 	    "Example:" "\n"


### PR DESCRIPTION
Add the following:
- support for file larger than 2GB on 32-bit system (issue seen on Raspbian Stretch) -D_FILE_OFFSET_BITS=64 to CFLAGS in the Makefile
- support output directly to stdout by specifying - as output file name ; this allows to pipe the output of gps-sdr-sim to an SDR player supporting IQ input on stdin. As, even on a Raspberry Pi 3, at 1 Msps, this wonderful program is able to output IQ samples faster than needed for realtime transmission.
- add an SDR player for the LimeSDR ; it reads IQ from stdin, supports 1, 8 or 16 bits samples, sample rates from 1Msps. There might be an issue with 8-bit mode, no successful test could be done