### PR TITLE
Add make target to download and extract ephemerides files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,9 @@ time: gps-sdr-sim
 	time ./gps-sdr-sim -e brdc3540.14n -u circle.csv -b 1
 	time ./gps-sdr-sim -e brdc3540.14n -u circle.csv -b 8
 	time ./gps-sdr-sim -e brdc3540.14n -u circle.csv -b 16
+
+YEAR?=$(shell date +"%Y")
+Y=$(patsubst 20%,%,$(YEAR))
+%.$(Y)n:
+	wget -q ftp://cddis.gsfc.nasa.gov/gnss/data/daily/$(YEAR)/brdc/$@.Z -O $@.Z
+	uncompress $@.Z


### PR DESCRIPTION
This makes it easy to download ephemerides data from the NASA website using make. E.g:

```
make brdc2250.18n
```

will automatically download and extract the brdc2250.18n ephemerides file. It is also possible to download ephemerides files  from different years (in this millennium) by setting the `YEAR` variable. E.g:

```
YEAR=2017 make brdc0580.17n
```