### PR TITLE
Add the option to define a custom user motion size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ gps-sdr-sim-lut
 
 # Netbeans project folder
 nbproject/*
+
+# Last used USER_MOTION_SIZE variable
+.user-motion-size

--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,32 @@ all: gps-sdr-sim
 SHELL=/bin/bash
 CC=gcc
 CFLAGS=-O3 -Wall -D_FILE_OFFSET_BITS=64
+ifdef USER_MOTION_SIZE
+CFLAGS+=-DUSER_MOTION_SIZE=$(USER_MOTION_SIZE)
+endif
 LDFLAGS=-lm
 
 gps-sdr-sim: gpssim.o
 	${CC} $< ${LDFLAGS} -o $@
 
+gpssim.o: .user-motion-size
+
+.user-motion-size: .FORCE
+	@if [ -f .user-motion-size ]; then \
+		if [ "`cat .user-motion-size`" != "$(USER_MOTION_SIZE)" ]; then \
+			echo "Updating .user-motion-size"; \
+			echo "$(USER_MOTION_SIZE)" >| .user-motion-size; \
+		fi; \
+	else \
+		echo "$(USER_MOTION_SIZE)" > .user-motion-size; \
+	fi;
+
 clean:
-	rm -f gpssim.o gps-sdr-sim *.bin
+	rm -f gpssim.o gps-sdr-sim *.bin .user-motion-size
 
 time: gps-sdr-sim
 	time ./gps-sdr-sim -e brdc3540.14n -u circle.csv -b 1
 	time ./gps-sdr-sim -e brdc3540.14n -u circle.csv -b 8
 	time ./gps-sdr-sim -e brdc3540.14n -u circle.csv -b 16
+
+.FORCE:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,22 @@ to RF using software-defined radio (SDR) platforms, such as
 $ gcc gpssim.c -lm -O3 -o gps-sdr-sim
 ```
 
+### Using bigger user motion files
+
+In order to use user motion files with more than 30000 samples (at 10Hz), the `USER_MOTION_SIZE`
+variable can be set to the maximum time of the user motion file in seconds. It is advisable to do
+this using make so gps-sdr-bin can update the size when needed. e.g:
+
+```
+$ make USER_MOTION_SIZE=4000
+```
+
+This variable can also be set when compiling directly with GCC:
+
+```
+$ gcc gpssim.c -lm -O3 -o gps-sdr-sim -DUSER_MOTION_SIZE=4000
+```
+
 ### Generating the GPS signal file
 
 A user-defined trajectory can be specified in either a CSV file, which contains 

--- a/gpssim.h
+++ b/gpssim.h
@@ -16,7 +16,9 @@
 #define MAX_CHAN (16)
 
 /*! \brief Maximum number of user motion points */
+#ifndef USER_MOTION_SIZE
 #define USER_MOTION_SIZE (3000) // max duration at 10Hz
+#endif
 
 /*! \brief Maximum duration for static mode*/
 #define STATIC_MAX_DURATION (86400) // second


### PR DESCRIPTION
This makes it possible to use bigger user motion files at the cost of some extra memory usage. See changes in README.

I tested this using a HackRF and it seems to work. I did notice some drift, but this seems to be present as well when using a static location. I don't know if there is a specific reason why the user motion file is limited to 3000 points apart from memory usage. If there is please let me know.

It might be even better to read the user motion file as a stream, essentially creating an unlimited maximum size, but I needed something quick.