### PR TITLE
Add missing dependency to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ LDFLAGS=-lm
 gps-sdr-sim: gpssim.o
 	${CC} $< ${LDFLAGS} -o $@
 
-gpssim.o: .user-motion-size
+gpssim.o: .user-motion-size gpssim.h
 
 .user-motion-size: .FORCE
 	@if [ -f .user-motion-size ]; then \


### PR DESCRIPTION
Hello

this PR fixes a fault in the Makefile. Specifically,  `gpssim.h` is missing from the rule in line 17. The build can cause incorrect results when the project is incrementally built. For example, any changes in `gpssim.h` will not cause the object file `gpssim.o` to be rebuilt.