### PR TITLE
improve error message for incorrect file name/path

### DIFF
--- a/gpssim.c
+++ b/gpssim.c
@@ -1930,6 +1930,11 @@ int main(int argc, char *argv[])
 		fprintf(stderr, "ERROR: No ephemeris available.\n");
 		exit(1);
 	}
+	else if (neph==-1)
+	{
+		fprintf(stderr, "ERROR: ephemeris file not found.\n");
+		exit(1);
+	}
 
 	if ((verb==TRUE)&&(ionoutc.vflg==TRUE))
 	{


### PR DESCRIPTION
This PR makes the error message a bit easier to understand if the nav file path or name is wrong.

Previously you would get the error:
```
ERROR: Invalid start time.
tmin =    0/00/00,00:00:00 (9:0)
tmax =    0/00/00,00:00:00 (0:0)
```
which looks like a date/time format parsing bug. Now you get the error:
```
ERROR: ephemeris file not found.
```