### PR TITLE
Modify -p option to allow setting of fixed gain value

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Options:
   -s <frequency>   Sampling frequency [Hz] (default: 2600000)
   -b <iq_bits>     I/Q data format [1/8/16] (default: 16)
   -i               Disable ionospheric delay for spacecraft scenario
-  -p               Disable path loss and hold power level constant
+  -p [fixed_gain]  Disable path loss and hold power level constant
   -v               Show details about simulated channels
 ```
 

--- a/gpssim.c
+++ b/gpssim.c
@@ -1707,7 +1707,7 @@ void usage(void)
 		"  -s <frequency>   Sampling frequency [Hz] (default: 2600000)\n"
 		"  -b <iq_bits>     I/Q data format [1/8/16] (default: 16)\n"
 		"  -i               Disable ionospheric delay for spacecraft scenario\n"
-		"  -p               Disable path loss and hold power level constant\n"
+		"  -p [fixed_gain]  Disable path loss and hold power level constant\n"
 		"  -v               Show details about simulated channels\n",
 		((double)USER_MOTION_SIZE) / 10.0, STATIC_MAX_DURATION);
 
@@ -1761,6 +1761,7 @@ int main(int argc, char *argv[])
 	int gain[MAX_CHAN];
 	double path_loss;
 	double ant_gain;
+	int fixed_gain = 128;
 	double ant_pat[37];
 	int ibs; // boresight angle index
 
@@ -1893,6 +1894,16 @@ int main(int argc, char *argv[])
 			ionoutc.enable = FALSE; // Disable ionospheric correction
 			break;
 		case 'p':
+			if (optind < argc && argv[optind][0] != '-') // Check if next item is an argument
+			{
+				fixed_gain = atoi(argv[optind]);
+				if (fixed_gain < 1 || fixed_gain > 128)
+				{
+					fprintf(stderr, "ERROR: Fixed gain must be between 1 and 128.\n");
+					exit(1);
+				}
+				optind++;  // Move past this argument for next iteration
+			}
 			path_loss_enable = FALSE; // Disable path loss
 			break;
 		case 'v':
@@ -2251,7 +2262,7 @@ int main(int argc, char *argv[])
 				if (path_loss_enable == TRUE)
 					gain[i] = (int)(path_loss * ant_gain * 128.0); // scaled by 2^7
 				else
-					gain[i] = 128; // hold the power level constant
+					gain[i] = fixed_gain; // hold the power level constant
 			}
 		}
 


### PR DESCRIPTION
By allowing the fixed gain to be set, the output power can be tuned to the amount of attenuation in the antenna path.  This is helpful in getting reliable CN0 values from the satellites.  Too much signal causes cross-correlations among the satellites. 

-p without options still works as before and sets the fixed gain to 128
-p with an integer between 1 and 128 configures the fixed gain dynamically.

NOTE: Perhaps 1 and 128 aren't the appropriate bounds. Feel free to update if there are more appropriate bounds. 