### PR TITLE
Fixing crash for very large USER_MOTION_SIZE values

### DIFF
--- a/gpssim.c
+++ b/gpssim.c
@@ -92,6 +92,8 @@ double ant_pat_db[37] = {
 
 int allocatedSat[MAX_SAT];
 
+double xyz[USER_MOTION_SIZE][3];
+
 /*! \brief Subtract two vectors of double
  *  \param[out] y Result of subtraction
  *  \param[in] x1 Minuend of subtraction
@@ -1743,7 +1745,7 @@ int main(int argc, char *argv[])
 	int iumd;
 	int numd;
 	char umfile[MAX_CHAR];
-	double xyz[USER_MOTION_SIZE][3];
+
 
 	int staticLocationMode = FALSE;
 	int nmeaGGA = FALSE;


### PR DESCRIPTION
As mentioned in #317 and #303 a segmentation fault occurs when compiling with large USER_MOTION_SIZE values, preventing the generation of very long simulations. The error is caused by allocating the array containing the xyz motion in the main function, and thus on the stack. With large motion sizes this leads to a stack overflow causing the crash. The very simple fix is to just declare the xyz variable as a global variable outside the main function putting it into the data section of memory. 